### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ repositories {
 ~~~
 /app/build.gradle
 ~~~
-compile 'com.github.zzz40500:AndroidSweetSheet:1.1.0'
+implementation 'com.github.zzz40500:AndroidSweetSheet:1.1.0'
 ~~~
 ###Usage:
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.